### PR TITLE
Port rule deb_packages 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,7 +25,3 @@ test --test_output=errors
 # Clean faster, but not on CI as container might
 # get killed before it finished cleaning
 clean --async
-
-# Fix current issue with rules_docker not being compatible
-# with Bazel 4.0.0 new default
-common --incompatible_restrict_string_escapes=false

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@aisbaa_rules_deb_packages//deb_packages:defs.bzl", "update_deb_packages")
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
 
 ###########
@@ -32,6 +33,17 @@ buildifier_test(
     timeout = "short",
     srcs = ["//:starlark_files"],
     lint_mode = "warn",
+)
+
+#############
+# Packaging #
+#############
+
+update_deb_packages(
+    name = "update_deb_packages",
+    pgp_keys = [
+        "@debian_bullseye_archive_key//file",
+    ],
 )
 
 ##############

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -73,12 +73,16 @@ http_archive(
 #############
 # Container #
 #############
+RULES_DOCKER_COMMIT = "e15c9ebf203b7fa708e69ff5f1cdcf427d7edf6f"
+
+RULES_DOCKER_SHA256 = "f4a39a410da7e497a7ccd19e28c69c93a851d6adb76798355a0c8ba9855e9b75"
+
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "1698624e878b0607052ae6131aa216d45ebb63871ec497f26c67455b34119c80",
-    strip_prefix = "rules_docker-0.15.0",
+    sha256 = RULES_DOCKER_SHA256,
+    strip_prefix = "rules_docker-{}".format(RULES_DOCKER_COMMIT),
     urls = [
-        "https://github.com/bazelbuild/rules_docker/releases/download/v0.15.0/rules_docker-v0.15.0.tar.gz",
+        "https://github.com/bazelbuild/rules_docker/archive/{}.zip".format(RULES_DOCKER_COMMIT),
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,8 +29,8 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchai
 go_download_sdk(
     name = "go_sdk",
     sdks = {
-        "darwin_amd64": ("go1.16rc1.darwin-amd64.tar.gz", "7c060b231b670321bd0f01085a4b2f7dcaf02d584cc50c42de7418158af23771"),
-        "linux_amd64": ("go1.16rc1.linux-amd64.tar.gz", "6a62610f56a04bae8702cd2bd73bfea34645c1b89ded3f0b81a841393b6f1f14"),
+        "darwin_amd64": ("go1.16.darwin-amd64.tar.gz", "6000a9522975d116bf76044967d7e69e04e982e9625330d9a539a8b45395f9a8"),
+        "linux_amd64": ("go1.16.linux-amd64.tar.gz", "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2"),
     },
     urls = [
         "https://dl.google.com/go/{}",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,7 @@
 #########
 # Bazel #
 #########
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 ##########
 # Golang #
@@ -111,3 +111,50 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 # This would load a different version of rules_python than the one needed in rules_docker
 # so we need to load it after container_deps()
 protobuf_deps()
+
+#############
+# Packaging #
+#############
+http_archive(
+    name = "aisbaa_rules_deb_packages",
+    sha256 = "efff23139e27eccf22f696dda42265903b1eff6dfa2420c4339aa98cdc80a7b9",
+    urls = [
+        "https://github.com/aisbaa/deb_packages/releases/download/v0.3-beta/deb_packages.tar.gz",
+    ],
+)
+
+load("@aisbaa_rules_deb_packages//deb_packages:deps.bzl", "deb_packages_setup")
+
+deb_packages_setup()
+
+# dowload gpg key for Debian 11
+http_file(
+    name = "debian_bullseye_archive_key",
+    sha256 = "0b7dc94b880f0b63e2093394b113cafd870badb86e020a35614f49b9d83beb1e",
+    urls = ["https://ftp-master.debian.org/keys/archive-key-11.asc"],
+)
+
+load("@aisbaa_rules_deb_packages//deb_packages:defs.bzl", "deb_repository")
+
+deb_repository(
+    name = "debian_bullseye_amd64_pkgs",
+    arch = "amd64",
+    distro = "bullseye",
+    distro_type = "debian",
+    mirrors = [
+        "http://snapshot.debian.org/archive/debian/20210223T211250Z/",
+        "http://deb.debian.org/debian",
+    ],
+    packages = {
+        "fd-find": "pool/main/r/rust-fd-find/fd-find_8.2.1-1+b1_amd64.deb",
+        "fzf": "pool/main/f/fzf/fzf_0.24.3-1+b1_amd64.deb",
+        "git": "pool/main/g/git/git_2.30.0-1_amd64.deb",
+        "ripgrep": "pool/main/r/rust-ripgrep/ripgrep_12.1.1-1+b1_amd64.deb",
+    },
+    packages_sha256 = {
+        "fd-find": "c9991b3efa8ccd41b8c27e204c4130562a86016787b9611a2141687906fec375",
+        "fzf": "ddc3f9a379d85a24471b4eb8ba729a91818ae65bc3cd9e73379b9fbe9167f56d",
+        "git": "32c6107a72665be54354585da69a464807a5c3d64654826307255da2c64bf930",
+        "ripgrep": "206c8365bbb26afd769b313d61002f8f15b655782d727d6c3b48dd3df7e57ed9",
+    },
+)

--- a/image/devtools/BUILD.bazel
+++ b/image/devtools/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@debian_bullseye_amd64_pkgs//debs:deb_packages.bzl", "debian_bullseye_amd64_pkgs")
+
+container_image(
+    name = "devtools_container",
+    base = "@amd64_ubuntu20.10//image:image",
+    debs = [
+        debian_bullseye_amd64_pkgs["git"],
+        debian_bullseye_amd64_pkgs["ripgrep"],
+        debian_bullseye_amd64_pkgs["fd-find"],
+        debian_bullseye_amd64_pkgs["fzf"],
+    ],
+    tags = [
+        "deb_packages_auto",
+    ],
+)
+
+container_test(
+    name = "devtools_image_test",
+    size = "small",
+    configs = [":devtools_image_test.yml"],
+    driver = "tar",
+    image = ":devtools_container",
+)

--- a/image/devtools/devtools_image_test.yml
+++ b/image/devtools/devtools_image_test.yml
@@ -1,0 +1,19 @@
+schemaVersion: "2.0.0"
+
+fileExistenceTests:
+  - name: "git-should-exits"
+    path: "/usr/bin/git"
+    shouldExist: true
+    permissions: '-rwxr-xr-x'
+  - name: "fd-should-exits"
+    path: "/usr/bin/fdfind"
+    shouldExist: true
+    permissions: '-rwxr-xr-x'
+  - name: "ripgrep-should-exits"
+    path: "/usr/bin/rg"
+    shouldExist: true
+    permissions: '-rwxr-xr-x'
+  - name: "fzf-should-exits"
+    path: "/usr/bin/fzf"
+    shouldExist: true
+    permissions: '-rwxr-xr-x'

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -1,9 +1,10 @@
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
+# External image test(s)
 container_test(
     name = "base_image_test",
     size = "small",
-    configs = ["//third_party:ubuntu_image_test.yml"],
+    configs = [":ubuntu_image_test.yml"],
     driver = "tar",
     image = "@amd64_ubuntu20.10//image:image",
 )


### PR DESCRIPTION
We need a way to install packages into our container image.

The provided method from rules_docker require a docker daemon to be available while the rules in distroless repo is not publicly applicable.

The alternative is using https://github.com/bazelbuild/rules_pkg/commits/main/deb_packages but it has been abandonned. A fork is available in https://github.com/aisbaa/deb_packages/ but a lot of the components, documentation seems to be quite out-of-date.

Attempt to source this rule locally instead and provide various improvements through iteration before upstreaming the changes.